### PR TITLE
fix 2 error

### DIFF
--- a/WebLoader/Nette/SymfonyConsole/GenerateCommand.php
+++ b/WebLoader/Nette/SymfonyConsole/GenerateCommand.php
@@ -39,7 +39,7 @@ class GenerateCommand extends \Symfony\Component\Console\Command\Command
 	}
 
 
-	protected function execute(InputInterface $input, OutputInterface $output): void
+	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
 		$force = $input->getOption('force');
 
@@ -47,7 +47,7 @@ class GenerateCommand extends \Symfony\Component\Console\Command\Command
 		foreach ($this->compilers as $compiler) {
 			$files = $compiler->generate(!$force);
 			foreach ($files as $file) {
-				$output->writeln($file->file);
+				$output->writeln($file->getFile());
 				$nofiles = false;
 			}
 		}
@@ -55,5 +55,7 @@ class GenerateCommand extends \Symfony\Component\Console\Command\Command
 		if ($nofiles) {
 			$output->writeln('No files generated.');
 		}
+
+		return 0;
 	}
 }


### PR DESCRIPTION
**- error1:**
Error: Cannot access protected property WebLoader\File::$file in bicisteadm/webloader-reload/WebLoader/Nette/SymfonyConsole/GenerateCommand.php:52

**- error2:**
TypeError: Return value of "WebLoader\Nette\SymfonyConsole\GenerateCommand::execute()" must be of the type int, "null" returned.